### PR TITLE
Fast Laravel Configuration

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -77,3 +77,6 @@ FIREBASE_CREDENTIALS=storage/app/firebase-credentials.json
 FIREBASE_PROJECT_ID=your-project-id
 
 APP_RELEASE_CI_UPLOAD_TOKEN=
+
+CFCACHE_API_TOKEN=
+CFCACHE_ZONE_ID=

--- a/app/Http/Middleware/ForceCache.php
+++ b/app/Http/Middleware/ForceCache.php
@@ -1,0 +1,53 @@
+<?php
+
+namespace App\Http\Middleware;
+
+use Closure;
+use Illuminate\Http\Request;
+use Symfony\Component\HttpFoundation\Response;
+
+class ForceCache
+{
+    public function handle(Request $request, Closure $next): Response
+    {
+        $response = $next($request);
+
+        if ($this->shouldCacheResponse($request, $response)) {
+            $response->headers->add([
+                'Cache-Control' => 'max-age=86400, public',
+                'ETag' => $this->generateEtag($request),
+            ]);
+            $response->headers->remove('Set-Cookie');
+        }
+
+        return $response;
+    }
+
+    public function shouldCacheResponse(Request $request, Response $response): bool
+    {
+        if (! $request->isMethod('GET')) {
+            return false;
+        }
+
+        if (! $response->isSuccessful()) {
+            return false;
+        }
+
+        if ($request->user()) {
+            return false;
+        }
+
+        return true;
+    }
+
+    private function generateEtag(Request $request): string
+    {
+        $uri = $request->path();
+
+        if ($request->getQueryString()) {
+            $uri .= '?' . $request->getQueryString();
+        }
+
+        return md5($uri . ':' . time());
+    }
+}

--- a/app/Http/Middleware/ForceCache.php
+++ b/app/Http/Middleware/ForceCache.php
@@ -45,9 +45,9 @@ class ForceCache
         $uri = $request->path();
 
         if ($request->getQueryString()) {
-            $uri .= '?' . $request->getQueryString();
+            $uri .= '?'.$request->getQueryString();
         }
 
-        return md5($uri . ':' . time());
+        return md5($uri.':'.time());
     }
 }

--- a/app/Http/Middleware/SetCacheControlHeader.php
+++ b/app/Http/Middleware/SetCacheControlHeader.php
@@ -1,0 +1,40 @@
+<?php
+
+namespace App\Http\Middleware;
+
+use Closure;
+use Illuminate\Http\Request;
+use Symfony\Component\HttpFoundation\Response;
+
+class SetCacheControlHeader
+{
+    public function handle(Request $request, Closure $next): Response
+    {
+        $response = $next($request);
+
+        if ($this->shouldCacheResponse($request, $response)) {
+            $response->headers->add([
+                'Cache-Control' => 'max-age=86400, public',
+            ]);
+        }
+
+        return $response;
+    }
+
+    public function shouldCacheResponse(Request $request, Response $response): bool
+    {
+        if (! $request->isMethod('GET')) {
+            return false;
+        }
+
+        if (! $response->isSuccessful()) {
+            return false;
+        }
+
+        if (app()->isLocal()) {
+            return false;
+        }
+
+        return true;
+    }
+}

--- a/bootstrap/app.php
+++ b/bootstrap/app.php
@@ -1,5 +1,6 @@
 <?php
 
+use Illuminate\Support\Facades\Route;
 use Illuminate\Console\Scheduling\Schedule;
 use Illuminate\Foundation\Application;
 use Illuminate\Foundation\Configuration\Exceptions;
@@ -15,6 +16,10 @@ return Application::configure(basePath: dirname(__DIR__))
         api: __DIR__ . '/../routes/api.php',
         channels: __DIR__ . '/../routes/channels.php',
         health: '/up',
+        then: function () {
+            Route::middleware('static')
+                ->group(base_path('routes/static.php'));
+        },
     )
     ->withMiddleware(function (Middleware $middleware) {
         $middleware->alias([
@@ -30,6 +35,11 @@ return Application::configure(basePath: dirname(__DIR__))
             Request::HEADER_X_FORWARDED_PROTO |
             Request::HEADER_X_FORWARDED_PREFIX
         );
+
+        $middleware->group('static', [
+            \App\Http\Middleware\SetCacheControlHeader::class,
+            \Illuminate\Routing\Middleware\SubstituteBindings::class,
+        ]);
     })
     ->withExceptions(function (Illuminate\Foundation\Configuration\Exceptions $exceptions) {
         $exceptions->render(function (TokenExpiredException $e, $request) {

--- a/bootstrap/app.php
+++ b/bootstrap/app.php
@@ -1,20 +1,20 @@
 <?php
 
-use Illuminate\Support\Facades\Route;
 use Illuminate\Console\Scheduling\Schedule;
 use Illuminate\Foundation\Application;
 use Illuminate\Foundation\Configuration\Exceptions;
 use Illuminate\Foundation\Configuration\Middleware;
 use Illuminate\Support\Facades\Broadcast;
+use Illuminate\Support\Facades\Route;
 use PHPOpenSourceSaver\JWTAuth\Exceptions\TokenExpiredException;
 use PHPOpenSourceSaver\JWTAuth\Exceptions\TokenInvalidException;
 use Symfony\Component\HttpFoundation\Request;
 
 return Application::configure(basePath: dirname(__DIR__))
     ->withRouting(
-        web: __DIR__ . '/../routes/web.php',
-        api: __DIR__ . '/../routes/api.php',
-        channels: __DIR__ . '/../routes/channels.php',
+        web: __DIR__.'/../routes/web.php',
+        api: __DIR__.'/../routes/api.php',
+        channels: __DIR__.'/../routes/channels.php',
         health: '/up',
         then: function () {
             Route::middleware('static')
@@ -55,44 +55,44 @@ return Application::configure(basePath: dirname(__DIR__))
         });
     })
     ->withExceptions(function (Exceptions $exceptions) {
-//        $exceptions->render(function (NotFoundHttpException $e, Request $request) {
-//            if ($request->is('api/*')) {
-//                return response()->json([
-//                    'error' => 'Resource or user not found',
-//                ], 404);
-//            }
-//        });
-//        $exceptions->render(function (BadRequestHttpException $e, Request $request) {
-//            if ($request->is('api/*')) {
-//                return response()->json([
-//                    'error' => 'Bad request',
-//                    'message' => $e->getMessage(),
-//                ], 400);
-//            }
-//        });
-//        $exceptions->render(function (AccessDeniedHttpException $e, Request $request) {
-//            if ($request->is('api/*')) {
-//                return response()->json([
-//                    'error' => 'Access denied',
-//                    'message' => $e->getMessage(),
-//                ], 403);
-//            }
-//        });
-//        $exceptions->render(function (AuthenticationException $e, Request $request) {
-//            if ($request->is('api/*')) {
-//                return response()->json([
-//                    'error' => 'Unauthorized',
-//                ], 401);
-//            }
-//        });
-//        $exceptions->render(function (Exception $e, Request $request) {
-//            if ($request->is('api/*')) {
-//                return response()->json([
-//                    'error' => 'Internal server error',
-//                    'message' => $e->getMessage(),
-//                ], 500);
-//            }
-//        });
+        //        $exceptions->render(function (NotFoundHttpException $e, Request $request) {
+        //            if ($request->is('api/*')) {
+        //                return response()->json([
+        //                    'error' => 'Resource or user not found',
+        //                ], 404);
+        //            }
+        //        });
+        //        $exceptions->render(function (BadRequestHttpException $e, Request $request) {
+        //            if ($request->is('api/*')) {
+        //                return response()->json([
+        //                    'error' => 'Bad request',
+        //                    'message' => $e->getMessage(),
+        //                ], 400);
+        //            }
+        //        });
+        //        $exceptions->render(function (AccessDeniedHttpException $e, Request $request) {
+        //            if ($request->is('api/*')) {
+        //                return response()->json([
+        //                    'error' => 'Access denied',
+        //                    'message' => $e->getMessage(),
+        //                ], 403);
+        //            }
+        //        });
+        //        $exceptions->render(function (AuthenticationException $e, Request $request) {
+        //            if ($request->is('api/*')) {
+        //                return response()->json([
+        //                    'error' => 'Unauthorized',
+        //                ], 401);
+        //            }
+        //        });
+        //        $exceptions->render(function (Exception $e, Request $request) {
+        //            if ($request->is('api/*')) {
+        //                return response()->json([
+        //                    'error' => 'Internal server error',
+        //                    'message' => $e->getMessage(),
+        //                ], 500);
+        //            }
+        //        });
     })
     ->withBroadcasting(Broadcast::class, attributes: [
         'guards' => ['api'],

--- a/composer.json
+++ b/composer.json
@@ -31,7 +31,8 @@
         "nunomaduro/collision": "^8.9.4",
         "pestphp/pest": "^3.8.6",
         "pestphp/pest-plugin-laravel": "^3.2",
-        "yasin_tgh/laravel-postman": "^1.4.6"
+        "yasin_tgh/laravel-postman": "^1.4.6",
+        "nexxai/laravel-cfcache": "^1.0"
     },
     "autoload": {
         "psr-4": {

--- a/routes/static.php
+++ b/routes/static.php
@@ -1,0 +1,12 @@
+<?php
+
+/*
+|--------------------------------------------------------------------------
+| Static Routes
+|--------------------------------------------------------------------------
+|
+| Here you may register the cacheable routes for your application.
+| These routes are loaded within the "static" middleware group
+| which adds the appropriate headers to cache the response.
+|
+*/


### PR DESCRIPTION
This pull request configures your Laravel application for caching responses. Notably by registering a [separate middleware group](https://laravel-news.com/separate-your-cloudflare-page-cache-with-a-middleware-group). You may then register routes within this middleware group to cache their response.

**Before merging**, you should:

- Checkout the `shift-173381` branch
- Review **all** pull request comments for additional changes
- Test your application ([no tests?](https://laravelshift.com/laravel-test-generator), [no CI?](https://laravelshift.com/ci-generator))

If you want to learn more about caching your Laravel application using free Cloudflare services, watch the [Fast Laravel](https://fastlaravel.com) video course.
